### PR TITLE
Fix crash when analysing a Twitch clip

### DIFF
--- a/yt-dlp-gui/Models/Format.cs
+++ b/yt-dlp-gui/Models/Format.cs
@@ -60,8 +60,8 @@ namespace yt_dlp_gui.Models {
             var r = 0;
             //比较 resolution
             if (x.height.HasValue && y.height.HasValue) {
-                var xr = x.width.Value * x.height.Value;
-                var yr = y.width.Value * y.height.Value;
+                var xr = (x.width ?? 1) * x.height.Value;
+                var yr = (y.width ?? 1) * y.height.Value;
                 if (xr != yr) {
                     return xr > yr ? -1 : 1;
                 }


### PR DESCRIPTION
Video formats returned by yt-dlp on Twitch clips only provide the height of the video and not the width, causing the ComparerVideo to crash when trying to access the width value.

Example of a format of a Twitch clip:
```json
        {
            "url": "https://production.assets.clips.twitchcdn.net/-0nUIEmwUG1212Pf1e9bkQ/AT-cm%7C-0nUIEmwUG1212Pf1e9bkQ-360.mp4?sig=795bb0b5e559baf5653438ba28fdf8850a553115&token=%7B%22authorization%22%3A%7B%22forbidden%22%3Afalse%2C%22reason%22%3A%22%22%7D%2C%22clip_uri%22%3A%22https%3A%2F%2Fproduction.assets.clips.twitchcdn.net%2F-0nUIEmwUG1212Pf1e9bkQ%2FAT-cm%257C-0nUIEmwUG1212Pf1e9bkQ.mp4%22%2C%22device_id%22%3Anull%2C%22expires%22%3A1665910534%2C%22user_id%22%3A%22%22%2C%22version%22%3A2%7D",
            "format_id": "360",
            "height": 360,
            "fps": 30,
            "protocol": "https",
            "ext": "mp4",
            "video_ext": "mp4",
            "audio_ext": "none",
            "format": "360 - 360p",
            "resolution": "360p",
            "dynamic_range": "SDR",
            "http_headers": {
                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.61 Safari/537.36",
                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
                "Accept-Language": "en-us,en;q=0.5",
                "Sec-Fetch-Mode": "navigate"
            }
        }
```

I added a default value on the width to 1 during the comparison, allowing the comparison to still work even without the width.