### PR TITLE
Crashfix decimalparse

### DIFF
--- a/yt-dlp-gui/ViewModels/Main.cs
+++ b/yt-dlp-gui/ViewModels/Main.cs
@@ -455,11 +455,11 @@ namespace yt_dlp_gui.Views {
                         // yt-dlp
                         if (!Data.DNStatus_Infos.ContainsKey("Downloader")) Data.DNStatus_Infos["Downloader"] = App.Lang.Status.Native;
                         var d = std.Split(',');
-                        if (decimal.TryParse(d[4], out decimal d_total)) {
+                        if (decimal.TryParse(d[4], CultureInfo.InvariantCulture, out decimal d_total)) {
                             s.Total = d_total;
                             s.Persent = decimal.Parse(d[3]) / d_total * 100; ;
                         } else {
-                            if (decimal.TryParse(d[1].TrimEnd('%'), out decimal d_persent)) {
+                            if (decimal.TryParse(d[1].TrimEnd('%'), CultureInfo.InvariantCulture, out decimal d_persent)) {
                                 s.Persent = d_persent;
                             }
                         }
@@ -480,7 +480,7 @@ namespace yt_dlp_gui.Views {
                         // aria2
                         Data.DNStatus_Infos["Downloader"] = "aria2c";
                         var d = Util.GetGroup(regAria, std);
-                        if (decimal.TryParse(d["persent"], out decimal o_persent)) {
+                        if (decimal.TryParse(d["persent"], CultureInfo.InvariantCulture, out decimal o_persent)) {
                             UpdatePersent(o_persent);
                         }
                         Data.DNStatus_Infos["Downloaded"] = d["downloaded"];
@@ -503,7 +503,7 @@ namespace yt_dlp_gui.Views {
                         // youtube-dl
                         if (!Data.DNStatus_Infos.ContainsKey("Downloader")) Data.DNStatus_Infos["Downloader"] = "youtube-dl";
                         var d = Util.GetGroup(regYTDL, std);
-                        if (decimal.TryParse(d["persent"], out decimal o_persent)) {
+                        if (decimal.TryParse(d["persent"], CultureInfo.InvariantCulture, out decimal o_persent)) {
                             UpdatePersent(o_persent);
                         }
                         Data.DNStatus_Infos["Total"] = d.GetValueOrDefault("total", "");

--- a/yt-dlp-gui/ViewModels/Main.cs
+++ b/yt-dlp-gui/ViewModels/Main.cs
@@ -4,6 +4,7 @@ using Swordfish.NET.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -463,8 +464,8 @@ namespace yt_dlp_gui.Views {
                             }
                         }
                         s.Downloaded = decimal.Parse(d[3]);
-                        if (decimal.TryParse(d[5], out decimal d_speed)) s.Speed = d_speed;
-                        if (decimal.TryParse(d[6], out decimal d_elapsed)) s.Elapsed = d_elapsed;
+                        if (decimal.TryParse(d[5], CultureInfo.InvariantCulture, out decimal d_speed)) s.Speed = d_speed;
+                        if (decimal.TryParse(d[6], CultureInfo.InvariantCulture, out decimal d_elapsed)) s.Elapsed = d_elapsed;
 
                         UpdatePersent(s.Persent);
 

--- a/yt-dlp-gui/yt-dlp-gui.csproj
+++ b/yt-dlp-gui/yt-dlp-gui.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <RootNamespace>yt_dlp_gui</RootNamespace>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>none</DebugType>
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
On Windows systems that don't use the '.' as decimal separator, the program would crash in decimal.TryParse() when processing the output of yt-dlp.exe
This pull request fixes that by using CultureInfo.Invariant.
Also, this pull request converts the project to .net8.0 as official .net6.0 support will end in November 2024