### PR TITLE
Improve Korean translation and update dependencies

### DIFF
--- a/languages/ko-KR/yt-dlp-gui.lang
+++ b/languages/ko-KR/yt-dlp-gui.lang
@@ -16,7 +16,7 @@ Main:
   DownloadThumb: 썸네일 다운로드
   # Main Tab - Buttons
   Analyze: 분석
-  Browse: 검색
+  Browse: 찾아보기
   Download: 다운로드
   Record: 녹화
   Cancel: 취소
@@ -59,7 +59,7 @@ Main:
   CookieWhenNeeded: 필요할 때
   CookieNever: 사용 안함
   CookieAlways: 항상 사용
-  CookieAsk: 뭍기
+  CookieAsk: 묻기
   CookieUse: 사용
   # Advance Tab - Aria2
   Aria2: Aria2
@@ -87,7 +87,7 @@ Main:
   NotificationsSound: 알림 소리
   SoundDefault: 기본
   SoundSystem: 시스템
-  SoundBrowse: 검색...
+  SoundBrowse: 찾아보기...
   # Options Tab - Always On Top
   AlwaysOnTop: 항상 위에 표시
   AlwaysOnTopEnabled: 활성화
@@ -95,7 +95,7 @@ Main:
   RememberWindowState: 창 위치 및 형태 기억하기
   RememberWindowPosition: 위치
   RememberWindowSize: 사이즈
-  Scale: Scale
+  Scale: 배율
   # Options Tab - Automatically download
   AutoDownload: 자동 다운로드
   AutoDownloadAnalysed: 분석 후에
@@ -104,7 +104,7 @@ Main:
   TemporaryTarget: 대상
   TemporaryLocale: 지역
   TemporarySystem: 시스템
-  TemporaryBrowse: 검색...
+  TemporaryBrowse: 찾아보기...
 # Window - About
 About:
   About: 정보
@@ -122,7 +122,7 @@ Releases:
   NoUpdated: 새 업데이트가 없습니다.
 # Dialog, Popups
 Dialog:
-  CookieRequired: 쿠기가 필요합니다. 사용하시겠습니까?
+  CookieRequired: 쿠키가 필요합니다. 사용하시겠습니까?
   FileExist: 파일이 이미 존재합니다. 덮어쓰시겠습니까?
   DownloadCompleted: 비디오 다운로드 완료!
   OpenFolder: 폴더 열기

--- a/yt-dlp-gui/yt-dlp-gui.csproj
+++ b/yt-dlp-gui/yt-dlp-gui.csproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>none</DebugType>
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DebugType>none</DebugType>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -44,11 +44,11 @@
 
   <ItemGroup>
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" />
-    <PackageReference Include="Markdig" Version="0.31.0" />
+    <PackageReference Include="Markdig" Version="0.45.0" />
     <PackageReference Include="MdXaml_migfree" Version="1.15.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" />
     <PackageReference Include="SharpClipboard" Version="3.5.2" />
     <PackageReference Include="Swordfish.NET.CollectionsV3" Version="3.3.12" />


### PR DESCRIPTION
## Summary

This PR fixes Korean translation typos, restores debug configuration for better developer experience, and updates NuGet packages to their latest stable versions.

## Changes

### 🌐 Korean Translation Fixes (6 items)

Fixed typos and improved terminology in `languages/ko-KR/yt-dlp-gui.lang`:

- **뭍기** → **묻기** (Ask) - Fixed incorrect verb
- **쿠기** → **쿠키** (Cookie) - Fixed typo
- **검색** → **찾아보기** (Browse) - Better translation
- **Scale** → **배율** - Localized English text

### 🐛 Debug Configuration

Enabled debug information in `yt-dlp-gui.csproj`:

Debug build: Changed `DebugType` from `none` to `full`
Release build: Changed `DebugType` from `none` to `embedded`

This allows developers to debug the application in Visual Studio.

### 📦 Package Updates

| Package | Version | 
|---------|---------|
| Markdig | 0.31.0 → 0.45.0 |
| Newtonsoft.Json | 13.0.3 → 13.0.4 |
| Microsoft.Xaml.Behaviors.Wpf | 1.1.39 → 1.1.135 |

All packages tested and compatible. Includes bug fixes and security patches.

## Testing

- ✅ Build successful (0 errors)
- ✅ All packages compatible
- ✅ No breaking changes

## Files Changed

- `languages/ko-KR/yt-dlp-gui.lang` - Translation improvements
- `yt-dlp-gui/yt-dlp-gui.csproj` - Debug config + package updates

---

**2 files changed, 11 insertions(+), 11 deletions(-)**